### PR TITLE
Fix "Call to a member function getPathname() on a non-object" 

### DIFF
--- a/src/Codesleeve/Stapler/StaplerServiceProvider.php
+++ b/src/Codesleeve/Stapler/StaplerServiceProvider.php
@@ -141,13 +141,16 @@ class StaplerServiceProvider extends ServiceProvider {
 	{
 		$this->app->bind('UploadedFile', function($app, $uploadedFile)
         {
-            $path = $uploadedFile->getPathname();
-            $originalName = $uploadedFile->getClientOriginalName();
-            $mimeType = $uploadedFile->getClientMimeType();
-            $size = $uploadedFile->getClientSize();
-            $error = $uploadedFile->getError();
+		  if ($uploadedFile !== STAPLER_NULL)
+		  {
+			$path = $uploadedFile->getPathname();
+			$originalName = $uploadedFile->getClientOriginalName();
+			$mimeType = $uploadedFile->getClientMimeType();
+			$size = $uploadedFile->getClientSize();
+			$error = $uploadedFile->getError();
             
-            return new UploadedFile($path, $originalName, $mimeType, $size, $error);
+			return new UploadedFile($path, $originalName, $mimeType, $size, $error);
+		  }
         });
 	}
 


### PR DESCRIPTION
Fix "Call to a member function getPathname() on a non-object"  when using STAPLER_NULL to remove an attachment.
