### PR TITLE
Fix negative coordinates bug on Resizer->resizeCrop

### DIFF
--- a/src/Codesleeve/Stapler/File/Image/Resizer.php
+++ b/src/Codesleeve/Stapler/File/Image/Resizer.php
@@ -158,8 +158,8 @@ class Resizer
 		list($optimalWidth, $optimalHeight) = $this->getOptimalCrop($image->getSize(), $width, $height);
 
 		// Find center - this will be used for the crop
-		$centerX = ($optimalWidth  / 2) - ($width  / 2);
-		$centerY = ($optimalHeight / 2) - ($height / 2);
+		$centerX = round( ($optimalWidth  / 2) - ($width  / 2), 2);
+		$centerY = round( ($optimalHeight / 2) - ($height / 2), 2);
 		
 		return $image->resize(new Box($optimalWidth, $optimalHeight))
 			->crop(new Point($centerX, $centerY), new Box($width, $height));


### PR DESCRIPTION
resizeCorp throw an error if the dimension of an image is wide and it's because the $centerX was negative value.
