### PR TITLE
Set attributes to NULL when remove attachment

### DIFF
--- a/src/Codesleeve/Stapler/Attachment.php
+++ b/src/Codesleeve/Stapler/Attachment.php
@@ -488,10 +488,10 @@ class Attachment
 			$this->queuedForDeletion = array_merge($this->queuedForDeletion, $filePaths);
 		}
 
-		$this->instanceWrite('file_name', '');
-		$this->instanceWrite('file_size', '');
-		$this->instanceWrite('content_type', '');
-		$this->instanceWrite('updated_at', '');
+		$this->instanceWrite('file_name', NULL);
+		$this->instanceWrite('file_size', NULL);
+		$this->instanceWrite('content_type', NULL);
+		$this->instanceWrite('updated_at', NULL);
     }
 
     /**


### PR DESCRIPTION
Hi, 

We changed the removed values to NULL because column file_size is of type integer and column updated_at is of type timestamp and setting them to '' results in an error.

Hope this gets merged soon! :smiley_cat: 
