### PR TITLE
Sets the ContentType when putting the object in S3

### DIFF
--- a/src/Codesleeve/Stapler/Storage/S3.php
+++ b/src/Codesleeve/Stapler/Storage/S3.php
@@ -83,7 +83,7 @@ class S3 implements StorageInterface
 	 */
 	public function move($file, $filePath)
 	{
- 		$this->getS3Client()->putObject(['Bucket' => $this->getBucket(), 'Key' => $filePath, 'SourceFile' => $file, 'ACL' => $this->attachedFile->ACL]);
+ 		$this->getS3Client()->putObject(['Bucket' => $this->getBucket(), 'Key' => $filePath, 'SourceFile' => $file, 'ContentType' => $this->attachedFile->contentType(), 'ACL' => $this->attachedFile->ACL]);
 	}
 
 	/**


### PR DESCRIPTION
The ContentType was not being set when putting the object in S3.  For example, after uploading an image to S3, when trying to access the URL of the image, the image would then try to download because the content type was set to application/octet-stream.  This sets the ContentType determined by the attachedFile.
