### PR TITLE
parse_url() attempts to parse Window file paths

### DIFF
--- a/src/Codesleeve/Stapler/IOWrapper.php
+++ b/src/Codesleeve/Stapler/IOWrapper.php
@@ -21,7 +21,7 @@ class IOWrapper
 			return $this->createFromArray($file);
 		}
 
-		if (array_key_exists('scheme', parse_url($file))) {
+		if (filter_var($file, FILTER_VALIDATE_URL) === TRUE) {
 			return $this->createFromUrl($file);
 		}
 


### PR DESCRIPTION
Fixed by utilizing PHP's internal filter validation instead.

Example of unexpected parsing:

``` php
C:\xampp\htdocs\contest>php artisan stapler:refresh Photo
Refreshing uploaded images...
Array
(
    [scheme] => C
    [path] => \xampp\htdocs\contest//system/Photo/photos/000/000/001/original/ba4a8fc0840011e3b64d12c7bfb8ccec_8.jpg
)


  [ErrorException]
  getimagesizefromstring(): Read error!



stapler:refresh [--attachments[="..."]] [class]


```
