### PR TITLE
Generates over the original image

### DIFF
--- a/src/Codesleeve/Stapler/Attachment.php
+++ b/src/Codesleeve/Stapler/Attachment.php
@@ -472,7 +472,7 @@ class Attachment
 
 		foreach ($this->styles as $style) 
 		{
-			$fileLocation = $this->storage == 'filesystem' ? $this->path() : $this->url();
+			$fileLocation = $this->storage == 'filesystem' ? $this->path() : $this->url('original');
 			$file = $this->IOWrapper->make($fileLocation);
 
 			if ($style->value && $file->isImage()) {


### PR DESCRIPTION
Generates over the original image, not on an already resized.
Before he took the set as the default image if the default image is not the original image was remade on an image that has already been processed, generating a low quality image.
