### PR TITLE
Added cache control key in put object to s3 client

### DIFF
--- a/src/Codesleeve/Stapler/Storage/S3.php
+++ b/src/Codesleeve/Stapler/Storage/S3.php
@@ -82,8 +82,21 @@ class S3 implements StorageInterface
 	 * @return void 
 	 */
 	public function move($file, $filePath)
-	{
- 		$this->getS3Client()->putObject(['Bucket' => $this->getBucket(), 'Key' => $filePath, 'SourceFile' => $file, 'ContentType' => $this->attachedFile->contentType(), 'ACL' => $this->attachedFile->ACL]);
+  {
+    $options = [];
+
+    if($ACL = $this->attachedFile->ACL)
+      $options['ACL'] = $ACL;
+
+    if($cacheControl = $this->attachedFile->CacheControl)
+      $options['CacheControl'] = $cacheControl;
+
+    $this->getS3Client()->putObject(array_merge([
+        'Bucket' => $this->getBucket(),
+        'Key' => $filePath,
+        'SourceFile' => $file,
+        'ContentType' => $this->attachedFile->contentType(),
+    ], $options));
 	}
 
 	/**
@@ -110,7 +123,7 @@ class S3 implements StorageInterface
 	 * 
 	 * @return string
 	 */
-	protected function getBucket()
+	public function getBucket()
 	{
 		$bucketName = $this->attachedFile->bucket;
 		if (!$this->bucketExists) {
@@ -126,7 +139,7 @@ class S3 implements StorageInterface
 	 * @param  string $bucketName
 	 * @return void
 	 */
-	protected function buildBucket($bucketName)
+	public function buildBucket($bucketName)
 	{
 		if (!$this->getS3Client()->doesBucketExist($bucketName, true)) {
 			$this->getS3Client()->createBucket(['ACL' => $this->attachedFile->ACL, 'Bucket' => $bucketName, 'LocationConstraint' => $this->attachedFile->region]);
@@ -142,7 +155,7 @@ class S3 implements StorageInterface
 	 * 	
 	 * @return S3Client
 	 */
-	protected function getS3Client()
+	public function getS3Client()
 	{
 		return $this->s3ClientManager->getS3Client($this->attachedFile);
 	}

--- a/src/config/s3.php
+++ b/src/config/s3.php
@@ -61,6 +61,20 @@ return [
 
 	/*
 	|--------------------------------------------------------------------------
+	| S3 CacheControl
+	|--------------------------------------------------------------------------
+	|
+  | This string will be the value for the S3 object's `CacheControl` option.
+  | If blank, the option will not be set.  The format is: `max-age=3600` as
+  | described here:
+  | http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html
+	|
+	*/
+
+	'CacheControl' => '',
+
+	/*
+	|--------------------------------------------------------------------------
 	| S3 Scheme (s3_protocol)
 	|--------------------------------------------------------------------------
 	|

--- a/tests/Stapler/Storage/S3Test.php
+++ b/tests/Stapler/Storage/S3Test.php
@@ -1,0 +1,102 @@
+<?php
+
+use Mockery as m;
+
+class StorageS3Test extends TestCase
+{
+
+  /**
+   * Teardown method.
+   *
+   * @return void
+   */
+  public function tearDown()
+  {
+    m::close();
+  }
+
+  /**
+   * Test that the default config options are forwarded to S3
+   *
+   * @return void
+   */
+  public function testMove()
+  {
+    $bucket = 'codename-production';
+    $file = "/doesn't matter.jpg";
+    $filePath = "s3://somewhere";
+    $contentType = 'image/jpeg';
+    $acl = 'public-read';
+
+    $config = m::mock('Codesleeve\Stapler\Config', ['mock config', [ 'ACL' => $acl ]])->makePartial();
+    $attachment = $this->getMockedAttachment($config, $contentType);
+
+    $s3Client = m::mock();
+    $s3Client->shouldReceive('putObject')->once()->with([
+      'Bucket' => $bucket,
+      'Key' => $filePath,
+      'SourceFile' => $file,
+      'ContentType' => $contentType,
+      'ACL' => $acl
+    ]);
+
+    $storage = $this->getMockedStorage($attachment, $bucket, $s3Client);
+    
+    $storage->move($file, $filePath);
+  }
+
+  /**
+   * Test that the config's CacheControl option is forwarded to S3
+   *
+   * @return void
+   */
+  public function testMoveWithOptions()
+  {
+    $bucket = 'codename-production';
+    $file = "/doesn't matter.jpg";
+    $filePath = "s3://somewhere";
+    $contentType = 'image/jpeg';
+    $acl = 'public-read';
+    $cacheControl = "max-age=3123123";
+
+    $config = m::mock('Codesleeve\Stapler\Config', ['mock config', [ 'ACL' => $acl, 'CacheControl' => $cacheControl ]])->makePartial();
+    $attachment = $this->getMockedAttachment($config, $contentType);
+
+    $s3Client = m::mock();
+    $s3Client->shouldReceive('putObject')->once()->with([
+      'Bucket' => $bucket,
+      'Key' => $filePath,
+      'SourceFile' => $file,
+      'ContentType' => $contentType,
+      'ACL' => $acl,
+      'CacheControl' => $cacheControl
+    ]);
+
+    $storage = $this->getMockedStorage($attachment, $bucket, $s3Client);
+    
+    $storage->move($file, $filePath);
+  }
+
+
+  private function getMockedAttachment($config, $contentType) {
+    $instance = m::mock();
+
+    $attachment = m::mock('Codesleeve\Stapler\Attachment')->makePartial();
+    $attachment->setConfig($config);
+    $attachment->setInstance($instance);
+    $attachment->shouldReceive('contentType')->andReturn($contentType);
+
+    return $attachment;
+  }
+
+  private function getMockedStorage($attachment, $bucket, $s3Client) {
+    $s3ClientManager = $this->app->make('S3ClientManager');
+
+    $storage = m::mock('Codesleeve\Stapler\Storage\S3', [$attachment, $s3ClientManager])->makePartial();
+    $storage->shouldReceive('getBucket')->andReturn($bucket);
+    $storage->shouldReceive('getS3Client')->andReturn($s3Client);
+
+    return $storage;
+  }
+
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,8 @@ use Illuminate\Support\Facades\App;
 
 class TestCase extends PHPUnit_Framework_TestCase {
 
+  protected $app;
+
 	/**
 	 * Bootstrap the test environemnt:
 	 * - Create an application instance and register it within itself.
@@ -14,10 +16,10 @@ class TestCase extends PHPUnit_Framework_TestCase {
 	 */
 	public function setUp()
 	{
-		$app = new Illuminate\Foundation\Application;
-		$app->instance('app', $app);
-		$app->register('Codesleeve\Stapler\StaplerServiceProvider');
-		Illuminate\Support\Facades\Facade::setFacadeApplication($app);
+		$this->app = new Illuminate\Foundation\Application;
+		$this->app->instance('app', $this->app);
+		$this->app->register('Codesleeve\Stapler\StaplerServiceProvider');
+		Illuminate\Support\Facades\Facade::setFacadeApplication($this->app);
 	}
 
 }


### PR DESCRIPTION
If you want CDNs to properly cache assets being served off S3, it's important to set the CacheControl header to something like 'max-age=1234'.
