### PR TITLE
Make the __wakeup() method public

### DIFF
--- a/src/Codesleeve/Stapler/Storage/S3ClientManager.php
+++ b/src/Codesleeve/Stapler/Storage/S3ClientManager.php
@@ -79,7 +79,7 @@ class S3ClientManager
      *
      * @return void
      */
-    private function __wakeup()
+    public function __wakeup()
     {
     }
 


### PR DESCRIPTION
It does not seem common to implement `__wakeup()` privately. I've been having issues with the Stapler S3 storage adapter where this method can't be called because it's private.

Is there a reason S3ClientManager's wakeup method is private?
