### PR TITLE
Stop the clearing of file on a soft delete

### DIFF
--- a/src/Codesleeve/Stapler/Attachment.php
+++ b/src/Codesleeve/Stapler/Attachment.php
@@ -398,13 +398,10 @@ class Attachment
 	 */
 	public function beforeDelete($instance)
 	{
-	        if(!$instance->softDelete)
-	        {
-	            $this->instance = $instance;
-	            $this->clear();
-	        }
+		if (!$instance->isSoftDeleting())
+			$this->clear();
+		$this->instance = $instance;
 	}
-
 	/**
 	 * Process the delete queue.
 	 *
@@ -414,8 +411,10 @@ class Attachment
 	public function afterDelete($instance)
 	{
 		$this->instance = $instance;
-		$this->flushDeletes();
+		if (!$instance->isSoftDeleting())
+			$this->flushDeletes();
 	}
+
 
 	/**
 	 * Destroys the attachment.  Has the same effect as previously assigning


### PR DESCRIPTION
Stops the file from being removed after a soft delete on the Model. Will still remove file when forceDelete method is called or soft deletes are not enabled
