### PR TITLE
specify path to stapler's config in boot

### DIFF
--- a/src/Codesleeve/Stapler/StaplerServiceProvider.php
+++ b/src/Codesleeve/Stapler/StaplerServiceProvider.php
@@ -27,7 +27,7 @@ class StaplerServiceProvider extends ServiceProvider {
 	 */
 	public function boot()
 	{
-		$this->package('codesleeve/stapler');
+		$this->package('codesleeve/stapler', 'stapler', __DIR__.'/../../');
 	}
 
 	/**


### PR DESCRIPTION
This allows for subclassing of the StaplerServiceProvider in Laravel 4.1+  Without specifying the path in the parent class then the config is read relative to the subclass and that definitely doesn't have Stapler's default config nearby.
