### PR TITLE
use relative path to stapler config

### DIFF
--- a/src/Codesleeve/Stapler/StaplerServiceProvider.php
+++ b/src/Codesleeve/Stapler/StaplerServiceProvider.php
@@ -27,7 +27,7 @@ class StaplerServiceProvider extends ServiceProvider {
 	 */
 	public function boot()
 	{
-		$this->package('codesleeve/stapler');
+		$this->package('codesleeve/stapler', 'stapler', __DIR__.'/../../');
 	}
 
 	/**


### PR DESCRIPTION
This is required for the latest version of Laravel, otherwise the default config is not loaded from the vendor directory.
