### PR TITLE
Fix 'bucket' typo to 'Bucket'

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,7 +40,7 @@ Default values:
 *   **url**: '/system/:class/:attachment/:id_partition/:style/:filename'
 *   **path**: ':laravel_root/public:url'
 *   **override_file_permissions**: null
-    
+
 ### S3-Storage-Configuration
 As your web application grows, you may find yourself in need of more robust file storage than what's provided by the local filesystem (e.g you're using multiple server instances and need a shared location for storing/accessing uploaded file assets).  Stapler provides a simple mechanism for easily storing and retreiving file objects with Amazon Simple Storage Service (Amazon S3).  In fact, aside from a few extra configuration settings, there's really no difference between s3 storage and filesystem storage when interacting with your attachments.  To get started with s3 storage you'll first need to add the AWS SDK to your composer.json file:
 
@@ -62,7 +62,7 @@ Description:
   * **secret**: This key plays the role of a  password . It's called secret because it is assumed to be known by the owner only.  A Password with Access Key forms a secure information set that confirms the user's identity. You are advised to keep your Secret Key in a safe place.
   * **region**: The region name of your bucket (e.g. 'us-east-1', 'us-west-1', 'us-west-2', 'eu-west-1').  Determines the base url where your objects are stored at (e.g a region of us-west-2 has a base url of s3-us-west-2.amazonaws.com).  The default value for this field is an empty (US Standard *).  You can go [here](http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region) for a more complete list/explanation of regions.
   * **scheme**: The protocol for the URLs generated to your S3 assets. Can be either 'http' or 'https'.  Defaults to 'http' when your ACL is 'public-read' (the default) and 'https' when your ACL is anything else.
-* **s3_object_config** 
+* **s3_object_config**
   * **bucket**: The bucket where you wish to store your objects.  Every object in Amazon S3 is stored in a bucket.  If the specified bucket doesn't exist Stapler will attempt to create it.  The bucket name will not be interpolated.
   * **ACL**: This is a string/array that should be one of the canned access policies that S3 provides (private, public-read, public-read-write, authenticated-read, bucket-owner-read, bucket-owner-full-control). The default for Stapler is public-read.  An associative array (style => permission) may be passed to specify permissions on a per style basis.
 * **path**: This is the key under the bucket in which the file will be stored. The URL will be constructed from the bucket and the path. This is what you will want to interpolate. Keys should be unique, like filenames, and despite the fact that S3 (strictly speaking) does not support directories, you can still use a / to separate parts of your file name.
@@ -74,6 +74,6 @@ Default values:
   * **region**: ''
   * **scheme**: 'http'
 * **s3_object_config**
-  *  **bucket**: ''
+  *  **Bucket**: ''
   *  **ACL**: 'public-read'
 * **path**: ':attachment/:id/:style/:filename'


### PR DESCRIPTION
Update docs. Minor issue, you're looking for 'Bucket' key but the docs read as 'bucket'.
