### PR TITLE
Allow invalid url

### DIFF
--- a/src/Codesleeve/Stapler/Storage/Filesystem.php
+++ b/src/Codesleeve/Stapler/Storage/Filesystem.php
@@ -53,7 +53,10 @@ class Filesystem implements StorageableInterface
 	{
 		foreach ($filePaths as $filePath) {
 			$directory = dirname($filePath);
-			$this->emptyDirectory($directory, true);
+			if (file_exists($filePath)) {
+				unlink($filePath);
+				$this->cleanEmptyDirectory($directory);
+			}
 		}
 	}
 
@@ -120,36 +123,21 @@ class Filesystem implements StorageableInterface
 	}
 
 	/**
-	 * Recursively delete the files in a directory.
+	 * Recursively delete empty directories.
 	 *
 	 * @desc Recursively loops through each file in the directory and deletes it.
 	 * @param string $directory
-	 * @param boolean $deleteDirectory
 	 */
-	protected function emptyDirectory($directory, $deleteDirectory = false)
+	protected function cleanEmptyDirectory($directory)
 	{
-		if (!is_dir($directory) || !($directoryHandle = opendir($directory))) {
-			return;
-		}
-
-		while (false !== ($object = readdir($directoryHandle)))
-		{
-			if ($object == '.' || $object == '..') {
-				continue;
-			}
-
-			if (!is_dir($directory.'/'.$object)) {
-				unlink($directory.'/'.$object);
-			}
-			else {
-				$this->emptyDirectory($directory.'/'.$object, true);	// The object is a folder, recurse through it.
-			}
-		}
-
-		if ($deleteDirectory)
-		{
-			closedir($directoryHandle);
+		$iterator = new \FilesystemIterator($directory);
+		$isDirEmpty = !$iterator->valid();
+		if ($isDirEmpty) {
 			rmdir($directory);
+			$directory = dirname($directory);
+			return $this->cleanEmptyDirectory($directory);
+		} else {
+			return true;
 		}
 	}
 }

--- a/src/Codesleeve/Stapler/Validator.php
+++ b/src/Codesleeve/Stapler/Validator.php
@@ -22,7 +22,7 @@ class Validator
 	 */
 	protected function validateFilesystemOptions(array $options)
 	{
-		if (preg_match("/:id\b/", $options['url']) !== 1 && preg_match("/:id_partition\b/", $options['url']) !== 1 && preg_match("/:hash\b/", $options['url']) !== 1) {
+		if ((!isset($options['allow_invalid_url']) || !$options['allow_invalid_url']) && preg_match("/:id\b/", $options['url']) !== 1 && preg_match("/:id_partition\b/", $options['url']) !== 1 && preg_match("/:hash\b/", $options['url']) !== 1) {
 			throw new Exceptions\InvalidUrlOptionException('Invalid Url: an id, id_partition, or hash interpolation is required.', 1);
 		}
 	}


### PR DESCRIPTION
This PR needs some explanation. 

## allow_invalid_url option

I wanted to manage attachment like wordpress does it so I set url doing so : 

    'url' => '/uploads/attachments/' . date('Y') . '/' . date('m') . '/:style.:filename',

I got an exception cause this url does not contain any :id / :hash so I chose to add a new option for developper willing to take the risk to break things **allow_invalid_url**

## FileSystem Storage Issue 

Your filesystem storage emptyDirectory on file removal. This is a problem when you plan to have multiple images in the same folder so I tweaked it a bit. My method works like this : 

- Delete the image
- Check if the directory containing the image is empty 
- If it is empty remove the directory and check if the parent directory is empty too (recursively deleting every parent empty directory)

Do not hesitate to tell me if something is wrong with my ideas I can still do some edits.