### PR TITLE
Remove any query strings at end of the filename

### DIFF
--- a/src/Codesleeve/Stapler/Factories/File.php
+++ b/src/Codesleeve/Stapler/Factories/File.php
@@ -79,6 +79,13 @@ class File
 		// Get the original name of the file
 		$name = pathinfo($file)['basename'];
 
+		// Remove any query strings at the end of the filename (i.e. Facebook graph profile images)
+		$nameQuery = strpos( $name, "?" );
+
+		if( $nameQuery !== false ) {
+			$name = substr( $name, 0, $nameQuery );
+		}
+
 		// Create a filepath for the file by storing it on disk.
 		$filePath = sys_get_temp_dir() . "/$name";
 		file_put_contents($filePath, $rawFile);


### PR DESCRIPTION
This fixes the problem you get when trying to save a profile image
pulled from the Facebook graph API.

Example image string:
https://fbcdn-profile-a.akamaihd.net/hprofile-ak-xpf1/v/t1.0-1/10222917_
10152323446467649_8217804623745092321_n.jpg?oh=6eba1683174247d11810cec33
0b2eb5e&oe=54953C34&**gda**=1422013996_8ff849b29f4370ae833f4b4d8078be5c

If we try to save this image with Stapler, we get the following  error:

Imagine\Exception\InvalidArgumentException
Saving image in
"jpg?oh=6eba1683174247d11810cec330b2eb5e&oe=54953C34&**gda**=1422013996_
8ff849b29f4370ae833f4b4d8078be5c" format is not supported, please use
one of the following extension: "gif", "jpeg", "png", "wbmp", "xbm"
