### PR TITLE
Allow support for S3 base_url config option.

### DIFF
--- a/src/Storage/S3.php
+++ b/src/Storage/S3.php
@@ -46,7 +46,7 @@ class S3 implements StorageableInterface
 	 */
 	public function url($styleName)
 	{
-		return $this->s3Client->getObjectUrl($this->attachedFile->s3_object_config['Bucket'], $this->path($styleName));
+		return $this->s3Client->getObjectUrl($this->attachedFile->s3_object_config['Bucket'], $this->path($styleName), null, ['PathStyle' => true]);
 	}
 
 	/**


### PR DESCRIPTION
This changes the `getObjectUrl` to use the `PathStyle` parameter in order to allow cnames to be used when generating the object url.