### PR TITLE
Overwrite models getAttributes() to include all attachments

### DIFF
--- a/src/ORM/EloquentTrait.php
+++ b/src/ORM/EloquentTrait.php
@@ -109,4 +109,14 @@ trait EloquentTrait
 
         parent::setAttribute($key, $value);
     }
+
+    /**
+     * Get all of the current attributes and attachment objects on the model.
+     *
+     * @return mixed
+     */
+    public function getAttributes()
+    {
+        return array_merge($this->attachedFiles, parent::getAttributes());
+    }
 }


### PR DESCRIPTION
If the trait overwrites `setAttribute()` and `getAttribute()` on the model to make attachments implicit attributes then the attachments should also be included in a call to all attributes of the model `getAttributes()`
