### PR TITLE
Rename bugfix

### DIFF
--- a/src/Storage/Filesystem.php
+++ b/src/Storage/Filesystem.php
@@ -112,7 +112,7 @@ class Filesystem implements StorageableInterface
 	 */
 	protected function moveFile($file, $filePath)
 	{
-		if (!rename($file, $filePath))
+		if (!@rename($file, $filePath))
         {
             $error = error_get_last();
             throw new Exceptions\FileException(sprintf('Could not move the file "%s" to "%s" (%s)', $file, $filePath, strip_tags($error['message'])));


### PR DESCRIPTION
There is a PHP issue (https://bugs.php.net/bug.php?id=50676) when renaming across volumes that causes an exception in Laravel even when the rename succeeds. This fixes it.
