### PR TITLE
Url with querystring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 composer.phar
 composer.lock
 .DS_Store
+phpunit.phar

--- a/src/Factories/File.php
+++ b/src/Factories/File.php
@@ -89,11 +89,11 @@ class File
 		curl_close($ch);
 
 		// Get the original name of the file
-    $pathinfo = pathinfo($file);
-    $name = $pathinfo['basename'];
-    if (strpos($name, '?') !== false) {
-      list($name, $queryString) = explode('?', $name);
-    }
+		$pathinfo = pathinfo($file);
+		$name = $pathinfo['basename'];
+		if (strpos($name, '?') !== false) {
+			list($name, $queryString) = explode('?', $name);
+		}
 
 		// Create a filepath for the file by storing it on disk.
 		$filePath = sys_get_temp_dir() . "/$name";

--- a/src/Factories/File.php
+++ b/src/Factories/File.php
@@ -89,8 +89,11 @@ class File
 		curl_close($ch);
 
 		// Get the original name of the file
-		$pathinfo = pathinfo($file); 
-		$name = urlencode($pathinfo['basename']);
+    $pathinfo = pathinfo($file);
+    $name = $pathinfo['basename'];
+    if (strpos($name, '?') !== false) {
+      list($name, $queryString) = explode('?', $name);
+    }
 
 		// Create a filepath for the file by storing it on disk.
 		$filePath = sys_get_temp_dir() . "/$name";

--- a/tests/Codesleeve/Stapler/Factories/FileTest.php
+++ b/tests/Codesleeve/Stapler/Factories/FileTest.php
@@ -77,17 +77,30 @@ class FileTest extends PHPUnit_Framework_TestCase
 
 	/**
 	 * Test that the file factory can create a Codesleeve\Stapler\UploadedFile
-	 * object from a redriect url
+	 * object from a redirect url
 	 *
 	 * @test
 	 * @return void
 	 */
-	public function it_should_be_able_to_build_a_stapler_uploaded_file_object_from_a_redriect_url()
+	public function it_should_be_able_to_build_a_stapler_uploaded_file_object_from_a_redirect_url()
 	{
 		$uploadedFile = File::create('https://graph.facebook.com/zuck/picture?type=large');
 
 		$this->assertInstanceOf('Codesleeve\Stapler\File\FileInterface', $uploadedFile);
-	}
+  }
+
+  /**
+   * Test that file created by file factory is not containing unnecessary quer string
+   *
+   * @test
+   * @group f
+   * @return void
+   */
+  public function it_should_be_able_to_build_a_stapler_uploaded_file_object_without_following_querystring_in_basename() {
+    $uploadedFile = File::create('https://graph.facebook.com/zuck/picture?type=large');
+
+    $this->assertFalse(strpos($uploadedFile->getFileName(), '?'));
+  }
 
 	/**
 	 * Test that the file factory can create a Codesleeve\Stapler\UploadedFile

--- a/tests/Codesleeve/Stapler/Factories/FileTest.php
+++ b/tests/Codesleeve/Stapler/Factories/FileTest.php
@@ -93,12 +93,23 @@ class FileTest extends PHPUnit_Framework_TestCase
 	 * Test that file created by file factory is not containing unnecessary quer string
 	 *
 	 * @test
-	 * @group f
 	 * @return void
 	 */
-	public function it_should_be_able_to_build_a_stapler_uploaded_file_object_without_following_querystring_in_basename() {
-		$uploadedFile = File::create('https://graph.facebook.com/zuck/picture?type=large');
+  public function it_should_be_able_to_build_a_stapler_uploaded_file_object_without_following_querystring_in_basename() {
+		$url = "https://graph.facebook.com/zuck/picture?type=large";
+		$uploadedFile = File::create($url);
 
+		$ch = curl_init($url);
+		curl_setopt($ch, CURLOPT_URL, $url);
+		curl_setopt($ch, CURLOPT_HEADER, true);
+		curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+		curl_exec($ch);
+		$info = curl_getinfo($ch, CURLINFO_EFFECTIVE_URL);
+		curl_close($ch);
+
+		// To make sure that the exact image URL has query string
+		$this->assertGreaterThanOrEqual(0, strpos($info, '?'));
 		$this->assertFalse(strpos($uploadedFile->getFileName(), '?'));
 	}
 

--- a/tests/Codesleeve/Stapler/Factories/FileTest.php
+++ b/tests/Codesleeve/Stapler/Factories/FileTest.php
@@ -89,18 +89,18 @@ class FileTest extends PHPUnit_Framework_TestCase
 		$this->assertInstanceOf('Codesleeve\Stapler\File\FileInterface', $uploadedFile);
   }
 
-  /**
-   * Test that file created by file factory is not containing unnecessary quer string
-   *
-   * @test
-   * @group f
-   * @return void
-   */
-  public function it_should_be_able_to_build_a_stapler_uploaded_file_object_without_following_querystring_in_basename() {
-    $uploadedFile = File::create('https://graph.facebook.com/zuck/picture?type=large');
+	/**
+	 * Test that file created by file factory is not containing unnecessary quer string
+	 *
+	 * @test
+	 * @group f
+	 * @return void
+	 */
+	public function it_should_be_able_to_build_a_stapler_uploaded_file_object_without_following_querystring_in_basename() {
+		$uploadedFile = File::create('https://graph.facebook.com/zuck/picture?type=large');
 
-    $this->assertFalse(strpos($uploadedFile->getFileName(), '?'));
-  }
+		$this->assertFalse(strpos($uploadedFile->getFileName(), '?'));
+	}
 
 	/**
 	 * Test that the file factory can create a Codesleeve\Stapler\UploadedFile


### PR DESCRIPTION
I had a problem with facebook login. Stapler encode url given by facebook, so then it messes the Imagine code since it looks for extension literally from the filename (instead of using mime type).

So, I in my case, removed the query string solved the problem.