### PR TITLE
Fix name composition if URL contains query string

### DIFF
--- a/src/Factories/File.php
+++ b/src/Factories/File.php
@@ -90,7 +90,7 @@ class File
 
 		// Get the original name of the file
 		$pathinfo = pathinfo($file); 
-		$name = urlencode($pathinfo['basename']);
+		$name = explode('%3F', urlencode($pathinfo['basename']))[0];
 
 		// Create a filepath for the file by storing it on disk.
 		$filePath = sys_get_temp_dir() . "/$name";


### PR DESCRIPTION
Previously saving image from URLs like "http://example.com/path/to/image.jpg?query" resulted into exception since file was saved with "*.jpg%3Fquery" extension and could not be processed by image processing library (at least not by Gd\Imagine). With this fix original extension is kept.