### PR TITLE
Fix remote URLs that contain query strings returning invalid extensions.

### DIFF
--- a/src/Factories/File.php
+++ b/src/Factories/File.php
@@ -88,18 +88,21 @@ class File
 		$rawFile = curl_exec($ch);
 		curl_close($ch);
 
+		// Remove the query string if it exists
+		// We should do this before fetching the pathinfo() so that the extension is valid
+		if (strpos($file, '?') !== false) {
+			list($file, $queryString) = explode('?', $file);
+		}
+
 		// Get the original name of the file
 		$pathinfo = pathinfo($file);
 		$name = $pathinfo['basename'];
-		if (strpos($name, '?') !== false) {
-			list($name, $queryString) = explode('?', $name);
-		}
 
 		// Create a filepath for the file by storing it on disk.
 		$filePath = sys_get_temp_dir() . "/$name";
 		file_put_contents($filePath, $rawFile);
 
-		if (empty($pathinfo['extension'])) 
+		if (empty($pathinfo['extension']))
 		{
 			$mimeType = MimeTypeGuesser::getInstance()->guess($filePath);
 			$extension = static::getMimeTypeExtensionGuesserInstance()->guess($mimeType);


### PR DESCRIPTION
There were 2 issues with the previous code:

1 - The file path was encoded so checking for `?` would fail as it should actually be checking for `%3F`.
2 - The `pathinfo()` would also return an invalid extension if the file path contained a query string. For example, if the image was `foo.jpg?query` then the pathinfo extension would be `jpg?query`.

By moving the query string detection before the pathinfo, it solves the previous 2 issues.