### PR TITLE
Uses an bootTraits approach

### DIFF
--- a/src/ORM/EloquentTrait.php
+++ b/src/ORM/EloquentTrait.php
@@ -36,22 +36,12 @@ trait EloquentTrait
     }
 
     /**
-     * The "booting" method of the model.
-     */
-    public static function boot()
-    {
-        parent::boot();
-
-        static::bootStapler();
-    }
-
-    /**
      * Register eloquent event handlers.
      * We'll spin through each of the attached files defined on this class
      * and register callbacks for the events we need to observe in order to
      * handle file uploads.
      */
-    public static function bootStapler()
+    public static function bootEloquentTrait()
     {
         static::saved(function($instance) {
             foreach($instance->attachedFiles as $attachedFile) {


### PR DESCRIPTION
it appears that overriding ::boot() method is not needed anymore.
Eloquent now boots all the traits. method name must conform to 'boot'.ucfirst(TraitClassName).

so, sorry for renaming bootStapler to bootEloquentTrait. atleast this doesn't break bc.

more info here https://github.com/laravel/framework/issues/4498