### PR TITLE
Remove boot() from EloquentTrait and replace with bootEloquentTrait()

### DIFF
--- a/src/ORM/EloquentTrait.php
+++ b/src/ORM/EloquentTrait.php
@@ -38,10 +38,8 @@ trait EloquentTrait
     /**
      * The "booting" method of the model.
      */
-    public static function boot()
+    public static function bootEloquentTrait()
     {
-        parent::boot();
-
         static::bootStapler();
     }
 


### PR DESCRIPTION
Fixes #51. 

Eloquent models may need to override boot() in order to add things like a global scope. Since a class overrides any methods in a trait, everything silently failed and it took quite awhile to track down why Stapler only half worked.

I've changed the method to bootEloquentTrait() so it gets called automatically and the model won't override it by accident.

From the Laravel 4.2 docs:

> If an Eloquent model uses a trait that has a method matching the bootNameOfTrait naming convention, that trait method will be called when the Eloquent model is booted, giving you an opportunity to register a global scope
