### PR TITLE
Interpolations now work correctly with ID's containing non-printable chars

### DIFF
--- a/src/Interpolator.php
+++ b/src/Interpolator.php
@@ -138,7 +138,7 @@ class Interpolator
     */
     protected function id(Attachment $attachment, $styleName = '')
     {
-        return $attachment->getInstance()->getKey();
+        return $this->ensurePrintable($attachment->getInstance()->getKey());
     }
 
     /**
@@ -175,7 +175,7 @@ class Interpolator
     */
     protected function idPartition(Attachment $attachment, $styleName = '')
     {
-        $id = $attachment->getInstance()->getKey();
+        $id = $this->ensurePrintable($attachment->getInstance()->getKey());
 
         if (is_numeric($id))
         {
@@ -226,5 +226,24 @@ class Interpolator
     protected function handleBackslashes($string)
     {
         return str_replace('\\', '/', ltrim($string, '\\'));
+    }
+
+    /**
+     * Utility method to ensure the input data only contains
+     * printable characters. This is especially important when
+     * handling non-printable ID's such as binary UUID's.
+     * 
+     * @param  mixed $input
+     * @return mixed
+     */
+    protected function ensurePrintable($input) {
+        if (!ctype_print($input)) {
+            // Hash the input data with SHA-256 to represent
+            // as printable characters, with minimum chances
+            // of the uniqueness being lost.
+            return hash('sha256', $input);
+        }
+
+        return $input;
     }
 }

--- a/src/Interpolator.php
+++ b/src/Interpolator.php
@@ -237,7 +237,7 @@ class Interpolator
      * @return mixed
      */
     protected function ensurePrintable($input) {
-        if (!ctype_print($input)) {
+        if (!is_numeric($input) && !ctype_print($input)) {
             // Hash the input data with SHA-256 to represent
             // as printable characters, with minimum chances
             // of the uniqueness being lost.


### PR DESCRIPTION
This fixes issue #128.