### PR TITLE
Feature/class interpolations

### DIFF
--- a/src/Interpolator.php
+++ b/src/Interpolator.php
@@ -45,6 +45,8 @@ class Interpolator
             ':url' => 'url',
             ':app_root' => 'appRoot',
             ':class' => 'getClass',
+            ':class_name' => 'getClassName',
+            ':namespace' => 'getNamespace',
             ':basename' => 'basename',
             ':extension' => 'extension',
             ':id' => 'id',
@@ -103,6 +105,36 @@ class Interpolator
     protected function getClass(Attachment $attachment, $styleName = '')
     {
         return $this->handleBackslashes($attachment->getInstanceClass());
+    }
+
+    /**
+     * Returns the current class name, not taking into account namespaces, e.g
+     * 'Swingline\Stapler' will become Stapler.
+     *
+     * @param Attachment $attachment
+     * @param string $styleName
+     * @return string
+    */
+    protected function getClassName(Attachment $attachment, $styleName = '')
+    {
+        $classComponents = explode('\\', $attachment->getInstanceClass());
+
+        return end($classComponents);
+    }
+
+    /**
+     * Returns the current class name, exclusively taking into account namespaces, e.g
+     * 'Swingline\Stapler' will become Swingline.
+     *
+     * @param Attachment $attachment
+     * @param string $styleName
+     * @return string
+    */
+    protected function getNamespace(Attachment $attachment, $styleName = '')
+    {
+        $classComponents = explode('\\', $attachment->getInstanceClass());
+
+        return implode('/', array_splice($classComponents, 0, count($classComponents) - 1));
     }
 
     /**

--- a/src/Interpolator.php
+++ b/src/Interpolator.php
@@ -134,7 +134,7 @@ class Interpolator
     {
         $classComponents = explode('\\', $attachment->getInstanceClass());
 
-        return implode('/', array_splice($classComponents, 0, count($classComponents) - 1));
+        return implode('/', array_slice($classComponents, 0, count($classComponents) - 1));
     }
 
     /**

--- a/src/Interpolator.php
+++ b/src/Interpolator.php
@@ -138,7 +138,7 @@ class Interpolator
     */
     protected function id(Attachment $attachment, $styleName = '')
     {
-        return $attachment->getInstance()->getKey();
+        return $this->ensurePrintable($attachment->getInstance()->getKey());
     }
 
     /**
@@ -175,7 +175,7 @@ class Interpolator
     */
     protected function idPartition(Attachment $attachment, $styleName = '')
     {
-        $id = $attachment->getInstance()->getKey();
+        $id = $this->ensurePrintable($attachment->getInstance()->getKey());
 
         if (is_numeric($id))
         {
@@ -226,5 +226,24 @@ class Interpolator
     protected function handleBackslashes($string)
     {
         return str_replace('\\', '/', ltrim($string, '\\'));
+    }
+
+    /**
+     * Utility method to ensure the input data only contains
+     * printable characters. This is especially important when
+     * handling non-printable ID's such as binary UUID's.
+     * 
+     * @param  mixed $input
+     * @return mixed
+     */
+    protected function ensurePrintable($input) {
+        if (!ctype_print($input)) {
+            // Hash the input data with SHA-256 to represent
+            // as printable characters, with minimum chances
+            // of the uniqueness being lost.
+            return hash('sha256', $input);
+        }
+
+        return $input;
     }
 }

--- a/src/Interpolator.php
+++ b/src/Interpolator.php
@@ -237,7 +237,7 @@ class Interpolator
      * @return mixed
      */
     protected function ensurePrintable($input) {
-        if (!ctype_print($input)) {
+        if (!is_numeric($input) && !ctype_print($input)) {
             // Hash the input data with SHA-256 to represent
             // as printable characters, with minimum chances
             // of the uniqueness being lost.

--- a/tests/Codesleeve/Stapler/InterpolatorTest.php
+++ b/tests/Codesleeve/Stapler/InterpolatorTest.php
@@ -91,12 +91,60 @@ class InterpolatorTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test the interpolator will correctly interpolate a string when
+     * using a class name
+     *
+     * @test
+     * @return void
+     */
+    public function it_should_be_able_to_interpolate_a_string_using_a_class_name()
+    {
+        $attachment         = $this->build_mock_attachment($this->interpolator, 'Foo\\Faz\\Baz\\TestModel');
+        $input              = '/system/:class_name/:attachment/:id_partition/:style/:filename';
+        $interpolatedString = $this->interpolator->interpolate($input, $attachment, 'thumbnail');
+
+        $this->assertEquals('/system/TestModel/photos/000/000/001/thumbnail/test.jpg', $interpolatedString);
+    }
+
+    /**
+     * Test the interpolator will correctly interpolate a string when
+     * using a namespace
+     *
+     * @test
+     * @return void
+     */
+    public function it_should_be_able_to_interpolate_a_string_using_a_namespace()
+    {
+        $attachment         = $this->build_mock_attachment($this->interpolator, 'Foo\\Faz\\Baz\\TestModel');
+        $input              = '/system/:namespace/:attachment/:id_partition/:style/:filename';
+        $interpolatedString = $this->interpolator->interpolate($input, $attachment, 'thumbnail');
+
+        $this->assertEquals('/system/Foo/Faz/Baz/photos/000/000/001/thumbnail/test.jpg', $interpolatedString);
+    }
+
+    /**
+     * Test the interpolator will correctly interpolate a string when
+     * using a namespace and class name
+     *
+     * @test
+     * @return void
+     */
+    public function it_should_be_able_to_interpolate_a_string_using_a_namespace_and_class_name()
+    {
+        $attachment         = $this->build_mock_attachment($this->interpolator, 'Foo\\Faz\\Baz\\TestModel');
+        $input              = '/system/:namespace/:class_name/:attachment/:id_partition/:style/:filename';
+        $interpolatedString = $this->interpolator->interpolate($input, $attachment, 'thumbnail');
+
+        $this->assertEquals('/system/Foo/Faz/Baz/TestModel/photos/000/000/001/thumbnail/test.jpg', $interpolatedString);
+    }
+
+    /**
      * Build a mock attachment object.
      *
      * @param  \Codesleeve\Stapler\Interpolator
      * @return \Codesleeve\Stapler\Attachment
      */
-    protected function build_mock_attachment($interpolator)
+    protected function build_mock_attachment($interpolator, $className = 'TestModel')
     {
         $instance = $this->build_mock_instance();
         $attachmentConfig = new AttachmentConfig('photo', ['styles' => [], 'default_style' => 'original']);
@@ -104,7 +152,7 @@ class InterpolatorTest extends PHPUnit_Framework_TestCase
         $resizer = new \Codesleeve\Stapler\File\Image\Resizer($imagine);
         
         $attachment = m::mock('Codesleeve\Stapler\Attachment[getInstanceClass]', [$attachmentConfig, $interpolator, $resizer]);
-        $attachment->shouldReceive('getInstanceClass')->andReturn('TestModel');
+        $attachment->shouldReceive('getInstanceClass')->andReturn($className);
         $attachment->setInstance($instance);
 
         return $attachment;


### PR DESCRIPTION
This fixes issue #124.

In order to maintain backwards compatibility with existing implementations using Stapler, the :class interpolation remains unchanged and will render the full namespace and class name combined. As such, two interpolations have been added:

* :class_name
* :namespace

Also, additional tests have been written for these two interpolations.