### PR TITLE
Add custom interpolations

### DIFF
--- a/src/Config/ConfigurableInterface.php
+++ b/src/Config/ConfigurableInterface.php
@@ -6,9 +6,10 @@ interface ConfigurableInterface
      * Retrieve a configuration value.
      *
      * @param string $name
+     * @param mixed default
      * @return mixed
      */
-    public function get($name);
+    public function get($name, $default);
 
     /**
      * Set a configuration value.

--- a/src/Config/IlluminateConfig.php
+++ b/src/Config/IlluminateConfig.php
@@ -13,7 +13,7 @@ class IlluminateConfig implements ConfigurableInterface
 
     /**
      * The name of the package this driver is being used with.
-     * 
+     *
      * @var string
      */
     protected $packageName;
@@ -33,18 +33,19 @@ class IlluminateConfig implements ConfigurableInterface
     /**
      * Retrieve a configuration value.
      *
-     * @param $name
+     * @param string $name
+     * @param mixed $default
      * @return mixed
      */
-    public function get($name){
-        return $this->config->get("$this->packageName::$name");
+    public function get($name, $default ){
+        return $this->config->get("$this->packageName::$name", $default);
     }
 
     /**
      * Set a configuration value.
      *
-     * @param $name
-     * @param $value
+     * @param string $name
+     * @param mixed $value
      * @return mixed
      */
     public function set($name, $value){

--- a/src/Config/NativeConfig.php
+++ b/src/Config/NativeConfig.php
@@ -58,15 +58,15 @@ class NativeConfig implements ConfigurableInterface
      * @param $name
      * @return mixed
      */
-    public function get($name)
+    public function get($name, $default = null)
     {
         list($group, $item) = array_pad(explode('.', $name), 2, null);
 
         if ($item) {
-            return $this->loadItemFromFile($group, $item);
+            return $this->loadItemFromFile($group, $item) ?: $default;
         }
 
-        return $this->loadAllFromFile($group);
+        return $this->loadAllFromFile($group) ?: $default;
     }
 
     /**


### PR DESCRIPTION
This is my solution to fix #107.  It also adds a default value to the config get() methods.

It's possible do define interpolations either as a closure within the config file, or as a static class method.
Example Config (stapler.php):
```php
    'custom_interpolations' => [
        ':style_lower' => function ($attachment, $styleName) {
            return strtolower($styleName);
        },
        ':style_upper' => ['MyApp\Interpolations\StyleUpper'], // Executes static "handle" method of StyleUpper class
        ':style_snake' => ['MyApp\Interpolations\StyleSnake', 'snake_case'], // Executes static "snake_case" method of StyleSnake class
    ],
```

TODO: Unit tests and documentation.