### PR TITLE
S3 File Delete is Broken

### DIFF
--- a/src/Storage/S3.php
+++ b/src/Storage/S3.php
@@ -68,7 +68,7 @@ class S3 implements StorageableInterface
     public function remove(array $filePaths)
     {
         if ($filePaths) {
-            $this->s3Client->deleteObjects(['Bucket' => $this->attachedFile->s3_object_config['Bucket'], 'Objects' => $this->getKeys($filePaths)]);
+            $this->s3Client->deleteObjects(['Bucket' => $this->attachedFile->s3_object_config['Bucket'], 'Delete' => ['Objects' => $this->getKeys($filePaths)]]);
         }
     }
 


### PR DESCRIPTION
AWS SDK throws an exception when deleting files. It request the objects array to be inside a Delete key.

AWS SDK Version: 3.0.7

This is the error I get:
Found 1 error while validating the input provided for the DeleteObjects operation:
[Delete] is missing and is a required parameter

This change fixes the problem.