### PR TITLE
Make AWS V3 Delete Work

### DIFF
--- a/src/Storage/S3.php
+++ b/src/Storage/S3.php
@@ -68,7 +68,11 @@ class S3 implements StorageableInterface
     public function remove(array $filePaths)
     {
         if ($filePaths) {
-            $this->s3Client->deleteObjects(['Bucket' => $this->attachedFile->s3_object_config['Bucket'], 'Objects' => $this->getKeys($filePaths)]);
+            if (defined('Aws\S3\S3Client::LATEST_API_VERSION')) {
+                $this->s3Client->deleteObjects(['Bucket' => $this->attachedFile->s3_object_config['Bucket'], 'Objects' => $this->getKeys($filePaths)]);
+            } else {
+                $this->s3Client->deleteObjects(['Bucket' => $this->attachedFile->s3_object_config['Bucket'], 'Delete' => ['Objects' => $this->getKeys($filePaths)]]);
+            }
         }
     }
 


### PR DESCRIPTION
I'm currently using AWS SDK 3.x, all other functions for s3 works fine but this delete... This small changes make it work with both versions, `2.x` and `3.x`...
