### PR TITLE
Reimplemented defaults => placeholders

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,9 +10,10 @@ The following configuration settings apply to stapler in general.
 
 *   **storage**: The underlying storage driver to uploaded files.  Defaults to filesystem (local storage) but can also be set to 's3' for use with AWS S3.
 *   **image_processing_libarary**: The underlying image processing library being used.  Defaults to GD but can also be set to Imagick or Gmagick.
-*   **default_url**: The default file returned when no file upload is present for a record.
-*   **default_style**: The default style returned from the Stapler file location helper methods.  An unaltered version of uploaded file
-    is always stored within the 'original' style, however the default_style can be set to point to any of the defined syles within the styles array.
+*   **placeholder**: The class to use for returning placeholders when no file upload is present for a record.
+*   **placeholder_url**: The placeholder file returned when no file upload is present for a record.
+*   **placeholder_style**: The placeholder style returned from the Stapler file location helper methods. An unaltered version of uploaded file
+    is always stored within the 'original' style, however the placeholder_style can be set to point to any of the defined syles within the styles array.
 *   **styles**: An array of image sizes defined for the file attachment.  Stapler will attempt to use to format the file upload
     into the defined style.
 *   **keep_old_files**: Set this to true in order to prevent older file uploads from being deleted from the file system when a record is updated.
@@ -22,8 +23,9 @@ The following configuration settings apply to stapler in general.
 Default values:
 *   **storage**: 'filesystem'
 *   **image_processing_library**: 'GD'
-*   **default_url**: '/:attachment/:style/missing.png'
-*   **default_style**: 'original'
+*   **placeholder**: null
+*   **placeholder_url**: '/:attachment/:style/missing.png'
+*   **placeholder_style**: 'original'
 *   **styles**: []
 *   **keep_old_files**: false
 *   **preserve_old_files**: false

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -34,18 +34,18 @@ Class Photo extends Eloquent implements StaplerableInterface
     public function __construct(array $attributes = array()) 
     {
         // Define an attachment named 'foo', with both thumbnail (100x100) and large (300x300) styles, 
-        // using custom url and default_url configurations:
+        // using custom url and placeholder_url configurations:
         $this->hasAttachedFile('foo', [
             'styles' => [
                 'thumbnail' => '100x100',
                 'large' => '300x300'
             ],
             'url' => '/system/:attachment/:id_partition/:style/:filename',
-            'default_url' => '/:attachment/:style/missing.jpg'
+            'placeholder_url' => '/:attachment/:style/missing.jpg'
         ]);
         
         // Define an attachment named 'bar', with both thumbnail (100x100) and large (300x300) styles, 
-        // using custom url and default_url configurations, with the keep_old_files flag set to true 
+        // using custom url and placeholder_url configurations, with the keep_old_files flag set to true 
         // (so that older file uploads aren't deleted from the file system) and image cropping turned on:
         $this->hasAttachedFile('bar', [
             'styles' => [
@@ -89,7 +89,7 @@ Class Photo extends Eloquent implements StaplerableInterface
                 'micro'     => '50X50'
             ],
             'url' => '/system/:attachment/:id_partition/:style/:filename',
-            'default_url' => '/defaults/:style/missing.png'
+            'placeholder_url' => '/defaults/:style/missing.png'
         ]);
         
         // Define an attachment named 'quux' that stores images remotely in an S3 bucket.
@@ -107,7 +107,7 @@ Class Photo extends Eloquent implements StaplerableInterface
             's3_object_config' => [
                 'bucket' => 'your.s3.bucket'
             ],
-            'default_url' => '/defaults/:style/missing.png',
+            'placeholder_url' => '/defaults/:style/missing.png',
             'keep_old_files' => true
         ]);
 
@@ -154,7 +154,7 @@ Display a resized thumbnail style image belonging to a user record
 Display the original image style (unmodified image):
 <img src="<?= $photo->foo->url('original') ?>">
 
-This also displays the unmodified original image (unless the :default_style interpolation has been set to a different style):
+This also displays the unmodified original image (unless the :placeholder_style interpolation has been set to a different style):
 <img src="<?= $photo->foo->url() ?>">
 ```
 

--- a/docs/interpolations.md
+++ b/docs/interpolations.md
@@ -1,5 +1,5 @@
 ## Interpolations
-With Stapler, uploaded files are accessed by configuring/defining path, url, and default_url strings which point to your uploaded file assets.  This is done via string interpolations.  Currently, the following interpolations are available for use:
+With Stapler, uploaded files are accessed by configuring/defining path, url, and placeholder_url strings which point to your uploaded file assets.  This is done via string interpolations.  Currently, the following interpolations are available for use:
 
 *   **:attachment** - The name of the file attachment as declared in the hasAttachedFile function, e.g 'avatar'.
 *   **:class**  - The classname of the model containing the file attachment, e.g User.  Stapler can handle namespacing of classes.

--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -4,6 +4,7 @@ use Codesleeve\Stapler\ORM\StaplerableInterface;
 use Codesleeve\Stapler\Storage\StorageableInterface;
 use Codesleeve\Stapler\File\Image\Resizer;
 use Codesleeve\Stapler\Factories\File as FileFactory;
+use Codesleeve\Stapler\Interfaces\PlaceholderInterface as Placeholder;
 
 class Attachment
 {
@@ -50,6 +51,13 @@ class Attachment
     protected $resizer;
 
     /**
+     * An instance of the placeholder classs for default images.
+     *
+     * @var \Codesleeve\Stapler\Interfaces\PlaceholderInterface
+     */
+    protected $placeholder;
+
+    /**
      * The uploaded/resized files that have been queued up for deletion.
      *
      * @var array
@@ -69,12 +77,14 @@ class Attachment
      * @param AttachmentConfig $config
      * @param Interpolator $interpolator
      * @param Resizer $resizer
+     * @param Placeholder $placeholder
      */
-    function __construct(AttachmentConfig $config, Interpolator $interpolator, Resizer $resizer)
+    function __construct(AttachmentConfig $config, Interpolator $interpolator, Resizer $resizer, Placeholder $placeholder)
     {
         $this->config = $config;
         $this->interpolator = $interpolator;
         $this->resizer = $resizer;
+        $this->placeholder = $placeholder;
     }
 
     /**
@@ -171,13 +181,33 @@ class Attachment
     }
 
     /**
-     * Accessor method for the uploadedFile property.
+     * Accessor method for the resizer property.
      *
      * @return Resizer
      */
     public function getResizer()
     {
         return $this->resizer;
+    }
+
+    /**
+     * Mutator method for the placeholder property.
+     *
+     * @param Placeholder $placeholder
+     */
+    public function setPlaceholder(Placeholder $placeholder)
+    {
+        $this->placeholder = $placeholder;
+    }
+
+    /**
+     * Accessor method for the placeholder property.
+     *
+     * @return Placeholder
+     */
+    public function getPlaceholder()
+    {
+        return $this->placeholder;
     }
 
     /**
@@ -581,11 +611,7 @@ class Attachment
     */
     protected function defaultUrl($styleName = '')
     {
-        if ($url = $this->default_url) {
-            return $this->getInterpolator()->interpolate($url, $this, $styleName);
-        }
-
-        return '';
+        return $this->getPlaceholder()->placehold($this->placeholder_url, $this, $styleName);
     }
 
     /**

--- a/src/Config/NativeConfig.php
+++ b/src/Config/NativeConfig.php
@@ -14,8 +14,8 @@ class NativeConfig implements ConfigurableInterface
             'base_path' => '',
             'storage' => 'filesystem',
             'image_processing_library' => 'Imagine\Gd\Imagine',
-            'default_url' => '/:attachment/:style/missing.png',
-            'default_style' => 'original',
+            'placeholder_url' => '/:attachment/:style/missing.png',
+            'placeholder_style' => 'original',
             'styles' => [],
             'keep_old_files' => false,
             'preserve_files' => false

--- a/src/Factories/Attachment.php
+++ b/src/Factories/Attachment.php
@@ -18,9 +18,9 @@ class Attachment
     {
         $options = static::mergeOptions($options);
         Stapler::getValidatorInstance()->validateOptions($options);
-        list($config, $interpolator, $resizer) = static::buildDependencies($name, $options);
+        list($config, $interpolator, $resizer, $placeholder) = static::buildDependencies($name, $options);
 
-        $attachment = new AttachmentObject($config, $interpolator, $resizer);
+        $attachment = new AttachmentObject($config, $interpolator, $resizer, $placeholder);
         $storageDriver = StorageFactory::create($attachment);
         $attachment->setStorageDriver($storageDriver);
 
@@ -40,7 +40,8 @@ class Attachment
         return [
             new AttachmentConfig($name, $options),
             Stapler::getInterpolatorInstance(),
-            Stapler::getResizerInstance($options['image_processing_library'])
+            Stapler::getResizerInstance($options['image_processing_library']),
+            Stapler::getPlaceholderInstance(),
         ];
     }
 

--- a/src/Interfaces/PlaceholderInterface.php
+++ b/src/Interfaces/PlaceholderInterface.php
@@ -1,0 +1,14 @@
+<?php namespace Codesleeve\Stapler\Interfaces;
+
+use Codesleeve\Stapler\Attachment;
+
+interface PlaceholderInterface
+{
+    /**
+     * Retrieve a configuration value.
+     *
+     * @param string $name
+     * @return mixed
+     */
+    public function placehold($url, Attachment $attachment, $styleName = '');
+}

--- a/src/Interpolator.php
+++ b/src/Interpolator.php
@@ -245,7 +245,7 @@ class Interpolator
     */
     protected function style(Attachment $attachment, $styleName = '')
     {
-        return $styleName ?: $attachment->default_style;
+        return $styleName ?: $attachment->placeholder_style;
     }
 
     /**

--- a/src/Placeholder.php
+++ b/src/Placeholder.php
@@ -1,0 +1,23 @@
+<?php namespace Codesleeve\Stapler;
+
+use Codesleeve\Stapler\Interfaces\PlaceholderInterface;
+
+class Placeholder implements PlaceholderInterface
+{
+    /**
+     * Interpolate a string.
+     *
+     * @param  string $string
+     * @param  Attachment $attachment
+     * @param  string $styleName
+     * @return string
+    */
+    public function placehold($url, Attachment $attachment, $styleName = '')
+    {
+        if ($url) {
+            return $attachment->getInterpolator()->interpolate($url, $attachment, $styleName);
+        }
+
+        return '';
+    }
+}

--- a/src/Stapler.php
+++ b/src/Stapler.php
@@ -1,6 +1,7 @@
 <?php namespace Codesleeve\Stapler;
 
 use Codesleeve\Stapler\Config\ConfigurableInterface;
+use Codesleeve\Stapler\Interfaces\PlaceholderInterface;
 use Codesleeve\Stapler\File\Image\Resizer;
 use Aws\S3\S3Client;
 
@@ -45,6 +46,13 @@ class Stapler
      * @var \Codesleeve\Stapler\File\Image\Resizer
      */
     protected static $resizer;
+
+    /**
+     * An instance of the placeholder class for creating placeholder images.
+     *
+     * @var \Codesleeve\Stapler\Placeholder
+     */
+    protected static $placeholder;
 
     /**
      * A configuration object instance.
@@ -158,6 +166,32 @@ class Stapler
     }
 
     /**
+     * Return a placeholder object instance.
+     *
+     * @return \Codesleeve\Stapler\Placeholder
+     */
+    public static function getPlaceholderInstance()
+    {
+        if (static::$placeholder === null)
+        {
+            static::$placeholder = new Placeholder;
+        }
+
+        return static::$placeholder;
+    }
+
+    /**
+     * Return a placeholder object instance.
+     *
+     * @param string $type
+     * @return \Codesleeve\Stapler\Placeholder
+     */
+    public static function setPlaceholderInstance(PlaceholderInterface $placeholder)
+    {
+        static::$placeholder = $placeholder;
+    }
+
+    /**
      * Return an S3Client object for a specific attachment type.
      * If no instance has been defined yet we'll buld one and then
      * cache it on the s3Clients property (for the current request only).
@@ -201,7 +235,8 @@ class Stapler
      *
      * @param ConfigurableInterface $config
      */
-    public static function setConfigInstance(ConfigurableInterface $config){
+    public static function setConfigInstance(ConfigurableInterface $config)
+    {
         static::$config = $config;
     }
 

--- a/tests/Codesleeve/Stapler/AttachmentTest.php
+++ b/tests/Codesleeve/Stapler/AttachmentTest.php
@@ -70,7 +70,7 @@ class AttachmentTest extends PHPUnit_Framework_TestCase
      * @test
      * @return void
      */
-    public function it_should_be_able_to_return_the_default_url_for_an_attachment_if_no_style_is_given()
+    public function it_should_be_able_to_return_the_placeholder_url_for_an_attachment_if_no_style_is_given()
     {
         $attachment = $this->build_attachment();
         $symfonyUploadedFile = new SymfonyUploadedFile(__DIR__ . '/Fixtures/empty.gif', 'empty.gif', null, null, null, true);
@@ -106,7 +106,7 @@ class AttachmentTest extends PHPUnit_Framework_TestCase
      * @test
      * @return void
      */
-    public function it_should_be_able_to_return_the_default_path_for_an_attachment_if_no_style_is_given($value='')
+    public function it_should_be_able_to_return_the_placeholder_path_for_an_attachment_if_no_style_is_given($value='')
     {
         $attachment = $this->build_attachment();
         $symfonyUploadedFile = new SymfonyUploadedFile(__DIR__ . '/Fixtures/empty.gif', 'empty.gif', null, null, null, true);
@@ -185,7 +185,7 @@ class AttachmentTest extends PHPUnit_Framework_TestCase
         $interpolator = new Interpolator;
         $attachmentConfig = new \Codesleeve\Stapler\AttachmentConfig('photo', [
             'styles' => [], 
-            'default_style' => 'original',
+            'placeholder_style' => 'original',
             'url' => '/system/:attachment/:id_partition/:style/:filename',
             'path' => ':app_root/public:url',
         ]);

--- a/tests/Codesleeve/Stapler/Fixtures/Models/Photo.php
+++ b/tests/Codesleeve/Stapler/Fixtures/Models/Photo.php
@@ -22,7 +22,7 @@ class Photo extends Eloquent implements StaplerableInterface
                 'thumbnail' => '100x100'
             ],
             'url' => '/system/:attachment/:id_partition/:style/:filename',
-            'default_url' => '/defaults/:style/missing.png',
+            'placeholder_url' => '/defaults/:style/missing.png',
             'convert_options' => [
                 'thumbnail' => ['quality' => 100, 'auto-orient' => true]
             ]

--- a/tests/Codesleeve/Stapler/InterpolatorTest.php
+++ b/tests/Codesleeve/Stapler/InterpolatorTest.php
@@ -49,7 +49,7 @@ class InterpolatorTest extends PHPUnit_Framework_TestCase
      * @test
      * @return void
      */
-    public function it_should_be_able_to_interpolate_a_string_using_the_default_style()
+    public function it_should_be_able_to_interpolate_a_string_using_the_placeholder_style()
     {
         $input = '/system/:class/:attachment/:id/:style/:filename';
         
@@ -147,7 +147,7 @@ class InterpolatorTest extends PHPUnit_Framework_TestCase
     protected function build_mock_attachment($interpolator, $className = 'TestModel')
     {
         $instance = $this->build_mock_instance();
-        $attachmentConfig = new AttachmentConfig('photo', ['styles' => [], 'default_style' => 'original']);
+        $attachmentConfig = new AttachmentConfig('photo', ['styles' => [], 'placeholder_style' => 'original']);
         $imagine = m::mock('Imagine\Image\ImagineInterface');
         $resizer = new \Codesleeve\Stapler\File\Image\Resizer($imagine);
         


### PR DESCRIPTION
Previously defaults could only be static images.

I wanted to support having autogenerated avatars that are unique for every user. In order to support this I "needed" to be able to change the defaults behavior.

For this reason I renamed defaults to placeholders and moved it out into it's own file that anyone can replace.

So now in my app I will write my own Placeholder and change the placeholder class in the cofig to mine. My placeholder class will then autogenerate an avatar for the model and attach it to the model.
