### PR TITLE
A note about Illuminate Database component

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -21,3 +21,11 @@ public static function boot()
     static::bootStapler();
 }
 ```
+
+When using the [Illuminate Database component](https://github.com/illuminate/database) without Laravel, make sure the event dispatcher is set!
+```
+// Set the event dispatcher
+use Illuminate\Events\Dispatcher;
+use Illuminate\Container\Container;
+$capsule->setEventDispatcher(new Dispatcher(new Container));
+```


### PR DESCRIPTION
When using Illuminate without Laravel, it's important to set the event dispatcher (which is optional) when using Stapler.