### PR TITLE
Ability to rename files on save

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -56,6 +56,19 @@ Class Photo extends Eloquent implements StaplerableInterface
             'keep_old_files' => true
         ]);
 
+        // Define an attachment named 'bar', rename filename to 'foo', with both thumbnail (100x100) and large (300x300) styles,
+        // using custom url and default_url configurations, with the keep_old_files flag set to true
+        // (so that older file uploads aren't deleted from the file system) and image cropping turned on:
+        $this->hasAttachedFile('bar', [
+            'new_filename' => 'foo',
+            'styles' => [
+                'thumbnail' => '100x100#',
+                'large' => '300x300#'
+            ],
+            'url' => '/system/:attachment/:id_partition/:style/:filename',
+            'keep_old_files' => true
+        ]);
+
         // Define an attachment named 'baz' that has a watermarked style.  Here, we define a style named 'watermarked'
         // that's a closure (so that we can do some complex watermarking stuff):
         $this->hasAttachedFile('baz', [

--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -128,7 +128,15 @@ class Attachment implements AttachmentInterface, JsonSerializable
         }
 
         $this->uploadedFile = FileFactory::create($uploadedFile);
-        $this->instanceWrite('file_name', $this->uploadedFile->getFilename());
+
+        // Rename file if option new_filename exists
+        if ($this->config->new_filename) {
+            $ext = pathinfo($this->uploadedFile->getFilename(), PATHINFO_EXTENSION);
+            $this->instanceWrite('file_name', $this->config->new_filename . '.' . $ext);
+        } else {
+            $this->instanceWrite('file_name', $this->uploadedFile->getFilename());
+        }
+
         $this->instanceWrite('file_size', $this->uploadedFile->getSize());
         $this->instanceWrite('content_type', $this->uploadedFile->getMimeType());
         $this->instanceWrite('updated_at', date('Y-m-d H:i:s'));


### PR DESCRIPTION
I added a 'new_filename' option to rename the file before saving when this option exists in the method hasAttachedFile();

Example:

```
        $this->hasAttachedFile('avatar', [
            'new_filename' => md5(strtotime('now')),
            'styles' => [
                'thumb' => '240x240'
            ],
        ]);
```