### PR TITLE
Add S3 temporary URLs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -69,6 +69,7 @@ Description:
   * **Bucket**: The bucket where you wish to store your objects.  Every object in Amazon S3 is stored in a bucket.  If the specified bucket doesn't exist Stapler will attempt to create it.  The bucket name will not be interpolated.
   * **ACL**: This is a string/array that should be one of the canned access policies that S3 provides (private, public-read, public-read-write, authenticated-read, bucket-owner-read, bucket-owner-full-control). The default for Stapler is public-read.  An associative array (style => permission) may be passed to specify permissions on a per style basis.
 * **path**: This is the key under the bucket in which the file will be stored. The URL will be constructed from the bucket and the path. This is what you will want to interpolate. Keys should be unique, like filenames, and despite the fact that S3 (strictly speaking) does not support directories, you can still use a / to separate parts of your file name.
+* **s3_object_url_expires**: This is a string representing a default expiration time for object URLs.  This adheres to the AWS expiration format (eg. +1 minutes) as described [here](http://docs.aws.amazon.com/aws-sdk-php/latest/class-Aws.S3.S3Client.html#_getObjectUrl).  This will almost always be used in conjunction with a 'private' ACL.
 
 Default values:
 * **s3_client_config**
@@ -80,3 +81,4 @@ Default values:
   *  **Bucket**: ''
   *  **ACL**: 'public-read'
 * **path**: ':attachment/:id/:style/:filename'
+* **s3_object_url_expires**: null

--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -298,7 +298,26 @@ class Attachment implements AttachmentInterface, JsonSerializable
     public function url($styleName = '')
     {
         if ($this->originalFilename()) {
-            return $this->storageDriver->url($styleName, $this);
+            return $this->storageDriver->url($styleName, null, $this);
+        }
+
+        return $this->defaultUrl($styleName);
+    }
+
+    /**
+     * Generates a temporary url to an uploaded file (or a resized version of it).
+     * AWS Documentation for $expires format at
+     * http://docs.aws.amazon.com/aws-sdk-php/latest/class-Aws.S3.S3Client.html#_getObjectUrl
+     *
+     * @param string $expires
+     * @param string $styleName
+     *
+     * @return string
+     */
+    public function tempUrl($expires, $styleName = '')
+    {
+        if ($this->originalFilename()) {
+            return $this->storageDriver->url($styleName, $expires, $this);
         }
 
         return $this->defaultUrl($styleName);

--- a/src/Interfaces/Attachment.php
+++ b/src/Interfaces/Attachment.php
@@ -135,6 +135,18 @@ interface Attachment
     public function url($styleName = '');
 
     /**
+     * Generates a temporary url to an uploaded file (or a resized version of it).
+     * AWS Documentation for $expires format at
+     * http://docs.aws.amazon.com/aws-sdk-php/latest/class-Aws.S3.S3Client.html#_getObjectUrl
+     *
+     * @param string $expires
+     * @param string $styleName
+     *
+     * @return string
+     */
+    public function tempUrl($expires, $styleName = '');
+
+    /**
      * Generates the file system path to an uploaded file (or a resized version of it).
      * This is used for saving files, etc.
      *

--- a/src/Interfaces/Storage.php
+++ b/src/Interfaces/Storage.php
@@ -8,10 +8,11 @@ interface Storage
      * Return the url for a file upload.
      *
      * @param string $styleName
+     * @param string $expires
      *
      * @return string
      */
-    public function url($styleName);
+    public function url($styleName, $expires = null);
 
     /**
      * For filesystem storage this method returns the path (on disk) of a file upload.

--- a/src/Storage/Filesystem.php
+++ b/src/Storage/Filesystem.php
@@ -29,10 +29,11 @@ class Filesystem implements StorageInterface
      * Return the url for a file upload.
      *
      * @param string $styleName
+     * @param string $expires
      *
      * @return string
      */
-    public function url($styleName)
+    public function url($styleName, $expires = null)
     {
         return $this->attachedFile->getInterpolator()->interpolate($this->attachedFile->url, $this->attachedFile, $styleName);
     }

--- a/src/Storage/S3.php
+++ b/src/Storage/S3.php
@@ -45,12 +45,17 @@ class S3 implements StorageInterface
      * Return the url for a file upload.
      *
      * @param string $styleName
+     * @param string $expires
      *
      * @return string
      */
-    public function url($styleName)
+    public function url($styleName, $expires = null)
     {
-        return $this->s3Client->getObjectUrl($this->attachedFile->s3_object_config['Bucket'], $this->path($styleName), null, ['PathStyle' => true]);
+        if (!$expires) {
+            $expires = $this->attachedFile->s3_object_url_expires;
+        }
+
+        return $this->s3Client->getObjectUrl($this->attachedFile->s3_object_config['Bucket'], $this->path($styleName), $expires, ['PathStyle' => true]);
     }
 
     /**


### PR DESCRIPTION
- Added a tempUrl() function to Attachments to fetch an expiring S3
object url with a given expiration string.
- Added a default S3 object url expiration string to the S3 config that
applies to all urls.
- Added documentation to the S3 config explaining usage of the new
s3_object_url_expires config property.