### PR TITLE
Fix MIME detection and too long URL names

### DIFF
--- a/src/Factories/File.php
+++ b/src/Factories/File.php
@@ -128,10 +128,10 @@ class File
         // Get the original name of the file
         $pathinfo = pathinfo($file);
         $name = $pathinfo['basename'];
-        $ext = $pathinfo['extension'];
+        $ext = isset($pathinfo['extension']) ? '.'.$pathinfo['extension'] : '';
 
         // Create a filepath for the file by storing it on disk.
-        $filePath = tempnam(sys_get_temp_dir(), 'stapler-').".{$ext}";
+        $filePath = tempnam(sys_get_temp_dir(), 'stapler-')."{$ext}";
         file_put_contents($filePath, $rawFile);
 
         if (!$ext) {
@@ -139,7 +139,7 @@ class File
             $extension = static::getMimeTypeExtensionGuesserInstance()->guess($mimeType);
 
             unlink($filePath);
-            $filePath = sys_get_temp_dir()."/$name".'.'.$extension;
+            $filePath = $filePath.'.'.$extension;
             file_put_contents($filePath, $rawFile);
         }
 

--- a/src/Factories/File.php
+++ b/src/Factories/File.php
@@ -123,7 +123,7 @@ class File
         curl_close($ch);
 
         // Remove the query string and hash if they exist
-        $file = preg_replace('/[#\?].*/', '', $file);
+        $file = preg_replace('/[&#\?].*/', '', $file);
 
         // Get the original name of the file
         $pathinfo = pathinfo($file);

--- a/src/Factories/File.php
+++ b/src/Factories/File.php
@@ -128,13 +128,13 @@ class File
         // Get the original name of the file
         $pathinfo = pathinfo($file);
         $name = $pathinfo['basename'];
-        $ext = isset($pathinfo['extension']) ? '.'.$pathinfo['extension'] : '';
+        $extension = isset($pathinfo['extension']) ? '.'.$pathinfo['extension'] : '';
 
         // Create a filepath for the file by storing it on disk.
-        $filePath = tempnam(sys_get_temp_dir(), 'stapler-')."{$ext}";
+        $filePath = tempnam(sys_get_temp_dir(), 'stapler-')."{$extension}";
         file_put_contents($filePath, $rawFile);
 
-        if (!$ext) {
+        if (!$extension) {
             $mimeType = MimeTypeGuesser::getInstance()->guess($filePath);
             $extension = static::getMimeTypeExtensionGuesserInstance()->guess($mimeType);
 

--- a/src/Factories/File.php
+++ b/src/Factories/File.php
@@ -122,21 +122,19 @@ class File
         $rawFile = curl_exec($ch);
         curl_close($ch);
 
-        // Remove the query string if it exists
-        // We should do this before fetching the pathinfo() so that the extension is valid
-        if (strpos($file, '?') !== false) {
-            list($file, $queryString) = explode('?', $file);
-        }
+        // Remove the query string and hash if they exist
+        $file = preg_replace('/[#\?].*/', '', $file);
 
         // Get the original name of the file
         $pathinfo = pathinfo($file);
         $name = $pathinfo['basename'];
+        $ext = $pathinfo['extension'];
 
         // Create a filepath for the file by storing it on disk.
-        $filePath = sys_get_temp_dir()."/$name";
+        $filePath = tempnam(sys_get_temp_dir(), 'stapler-').".{$ext}";
         file_put_contents($filePath, $rawFile);
 
-        if (empty($pathinfo['extension'])) {
+        if (!$ext) {
             $mimeType = MimeTypeGuesser::getInstance()->guess($filePath);
             $extension = static::getMimeTypeExtensionGuesserInstance()->guess($mimeType);
 

--- a/src/Factories/File.php
+++ b/src/Factories/File.php
@@ -131,7 +131,8 @@ class File
         $extension = isset($pathinfo['extension']) ? '.'.$pathinfo['extension'] : '';
 
         // Create a filepath for the file by storing it on disk.
-        $filePath = tempnam(sys_get_temp_dir(), 'stapler-')."{$extension}";
+        $lockFile = tempnam(sys_get_temp_dir(), 'stapler-');
+        $filePath = $lockFile."{$extension}";
         file_put_contents($filePath, $rawFile);
 
         if (!$extension) {
@@ -142,6 +143,8 @@ class File
             $filePath = $filePath.'.'.$extension;
             file_put_contents($filePath, $rawFile);
         }
+        
+        unlink($lockFile);
 
         return new StaplerFile($filePath);
     }


### PR DESCRIPTION
This PR fixes a condition where the file attachment would fail to save in the filesystem because the filesystem name was derived from the URL basename that was too long for the filesystem to support.

It also fixes a small issue where hash anchors in URLs would cause file extensions from `pathinfo()` to be incorrect