### PR TITLE
Guzzle support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "mockery/mockery": "0.8.0",
         "aws/aws-sdk-php": "2.4.*@dev",
         "illuminate/database": "4.*|5.*",
-        "illuminate/config": "4.*|5.*"
+        "illuminate/config": "4.*|5.*",
+        "guzzlehttp/guzzle": "^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Factories/File.php
+++ b/src/Factories/File.php
@@ -138,7 +138,7 @@ class File
             $extension = static::getMimeTypeExtensionGuesserInstance()->guess($mimeType);
             $srcPath = $filePath;
             $filePath = $filePath.'.'.$extension;
-            mv($srcPath, $filePath);
+            rename($srcPath, $filePath);
         }
 
         return new StaplerFile($filePath);

--- a/src/Factories/File.php
+++ b/src/Factories/File.php
@@ -112,37 +112,33 @@ class File
      *
      * @return \Codesleeve\Stapler\File\File
      */
-    protected static function createFromUrl($file)
+    protected static function createFromUrl($url)
     {
-        $ch = curl_init($file);
-        curl_setopt($ch, CURLOPT_HEADER, 0);
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
-        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
-        $rawFile = curl_exec($ch);
-        curl_close($ch);
-
-        // Remove the query string if it exists
-        // We should do this before fetching the pathinfo() so that the extension is valid
-        if (strpos($file, '?') !== false) {
-            list($file, $queryString) = explode('?', $file);
-        }
+        // Remove the query string and hash if they exist
+        $file = preg_replace('/[&#\?].*/', '', $url);
 
         // Get the original name of the file
         $pathinfo = pathinfo($file);
         $name = $pathinfo['basename'];
-
-        // Create a filepath for the file by storing it on disk.
-        $filePath = sys_get_temp_dir()."/$name";
-        file_put_contents($filePath, $rawFile);
+        $extension = isset($pathinfo['extension']) ? '.'.$pathinfo['extension'] : '';
+        $filePath = tempnam(sys_get_temp_dir(), 'stapler-')."{$extension}";
+        
+        $c = new \GuzzleHttp\Client();
+        $response = $c->request('GET', $url, [
+          'sink'=>$filePath,
+        ]);
+        
+        if($response->getStatusCode()!=200)
+        {
+          throw new \Codesleeve\Stapler\Exceptions\FileException('Invalid URI returned HTTP code ', $response->getStatusCode());
+        }
 
         if (empty($pathinfo['extension'])) {
             $mimeType = MimeTypeGuesser::getInstance()->guess($filePath);
             $extension = static::getMimeTypeExtensionGuesserInstance()->guess($mimeType);
-
-            unlink($filePath);
-            $filePath = sys_get_temp_dir()."/$name".'.'.$extension;
-            file_put_contents($filePath, $rawFile);
+            $srcPath = $filePath;
+            $filePath = $filePath.'.'.$extension;
+            mv($srcPath, $filePath);
         }
 
         return new StaplerFile($filePath);

--- a/src/Factories/File.php
+++ b/src/Factories/File.php
@@ -121,8 +121,9 @@ class File
         $pathinfo = pathinfo($file);
         $name = $pathinfo['basename'];
         $extension = isset($pathinfo['extension']) ? '.'.$pathinfo['extension'] : '';
-        $filePath = tempnam(sys_get_temp_dir(), 'stapler-')."{$extension}";
-        
+        $lockFile = tempnam(sys_get_temp_dir(), 'stapler-');
+        $filePath = $lockFile."{$extension}";
+
         $c = new \GuzzleHttp\Client();
         $response = $c->request('GET', $url, [
           'sink'=>$filePath,
@@ -140,6 +141,8 @@ class File
             $filePath = $filePath.'.'.$extension;
             rename($srcPath, $filePath);
         }
+        
+        unlink($lockFile);
 
         return new StaplerFile($filePath);
     }


### PR DESCRIPTION
A small update to introduce Guzzle support rather than raw `curl`. This feels more reliable to me and also fixes a couple bugs in `createFromUrl`:
1. The old implementation saved responses even when they were not 200 HTTP status
2. The old implementation loaded the whole response into memory before saving. This saves directly to file, far more memory efficient.

These can be accomplished with raw curl too, but I felt Guzzle modernized things a bit and made the process more reliable. Guzzle also supports environments without curl.

Incidentally, I think this would allow us to close #102  too because Guzzle probably already addresses the problem.
