### PR TITLE
Fix duplicate unlink

### DIFF
--- a/src/Factories/File.php
+++ b/src/Factories/File.php
@@ -139,7 +139,6 @@ class File
             $mimeType = MimeTypeGuesser::getInstance()->guess($filePath);
             $extension = static::getMimeTypeExtensionGuesserInstance()->guess($mimeType);
 
-            unlink($filePath);
             $filePath = $filePath.'.'.$extension;
             file_put_contents($filePath, $rawFile);
         }


### PR DESCRIPTION
This `unlink` causes two errors in the test suite. This is because when a file is added with no extension, the `$filePath` at this point is the same as the `$lockFile` path (as it has no extension). The attempt to unlink the `$lockFile` then has an error as the file does not exist anymore.

Errors from phpunit before removal of `unlink`:
```
There were 2 errors:

1) Codesleeve\Stapler\Factories\FileTest::it_should_be_able_to_build_a_stapler_uploaded_file_object_from_a_redirect_url
unlink(/tmp/stapler-6hHfIS): No such file or directory

/home/squigg/packages/stapler/src/Factories/File.php:147
/home/squigg/packages/stapler/src/Factories/File.php:40
/home/squigg/packages/stapler/tests/Codesleeve/Stapler/Factories/FileTest.php:81

2) Codesleeve\Stapler\Factories\FileTest::it_should_be_able_to_build_a_stapler_uploaded_file_object_without_following_querystring_in_basename
unlink(/tmp/stapler-sin4Nu): No such file or directory

/home/squigg/packages/stapler/src/Factories/File.php:147
/home/squigg/packages/stapler/src/Factories/File.php:40
/home/squigg/packages/stapler/tests/Codesleeve/Stapler/Factories/FileTest.php:94
```