### PR TITLE
Return class name and namespace lowercased

### DIFF
--- a/src/Interpolator.php
+++ b/src/Interpolator.php
@@ -126,8 +126,9 @@ class Interpolator implements InterpolatorInterface
     protected function getClassName(AttachmentInterface $attachment, string $styleName = '')
     {
         $classComponents = explode('\\', $attachment->getInstanceClass());
+        $className = end($classComponents);
 
-        return end($classComponents);
+        return strtolower($className);
     }
 
     /**
@@ -142,8 +143,9 @@ class Interpolator implements InterpolatorInterface
     protected function getNamespace(AttachmentInterface $attachment, string $styleName = '')
     {
         $classComponents = explode('\\', $attachment->getInstanceClass());
-
-        return implode('/', array_slice($classComponents, 0, count($classComponents) - 1));
+        $namespace = implode('/', array_slice($classComponents, 0, count($classComponents) - 1));
+          
+        return strtolower($namespace);
     }
 
     /**

--- a/tests/Codesleeve/Stapler/InterpolatorTest.php
+++ b/tests/Codesleeve/Stapler/InterpolatorTest.php
@@ -95,7 +95,7 @@ class InterpolatorTest extends PHPUnit_Framework_TestCase
         $input = '/system/:class_name/:attachment/:id_partition/:style/:filename';
         $interpolatedString = $this->interpolator->interpolate($input, $attachment, 'thumbnail');
 
-        $this->assertEquals('/system/TestModel/photos/000/000/001/thumbnail/test.jpg', $interpolatedString);
+        $this->assertEquals('/system/testmodel/photos/000/000/001/thumbnail/test.jpg', $interpolatedString);
     }
 
     /**
@@ -110,7 +110,7 @@ class InterpolatorTest extends PHPUnit_Framework_TestCase
         $input = '/system/:namespace/:attachment/:id_partition/:style/:filename';
         $interpolatedString = $this->interpolator->interpolate($input, $attachment, 'thumbnail');
 
-        $this->assertEquals('/system/Foo/Faz/Baz/photos/000/000/001/thumbnail/test.jpg', $interpolatedString);
+        $this->assertEquals('/system/foo/faz/baz/photos/000/000/001/thumbnail/test.jpg', $interpolatedString);
     }
 
     /**


### PR DESCRIPTION
See #160 

The purpose of this change is to make links more consistent with the naming conventions
commonly used for files and folders in web applications.
