### PR TITLE
Added condition for AWS IAM Profile support and not to require AWS Credentials in the defines

### DIFF
--- a/src/Storage/S3.php
+++ b/src/Storage/S3.php
@@ -50,7 +50,8 @@ class S3 implements StorageInterface
      */
     public function url($styleName)
     {
-        return $this->s3Client->getObjectUrl($this->attachedFile->s3_object_config['Bucket'], $this->path($styleName), null, ['PathStyle' => true]);
+        //return $this->s3Client->getObjectUrl($this->attachedFile->s3_object_config['Bucket'], $this->path($styleName), null, ['PathStyle' => true]);
+	return $this->signedurl($styleName);
     }
 
 

--- a/src/Storage/S3.php
+++ b/src/Storage/S3.php
@@ -53,6 +53,26 @@ class S3 implements StorageInterface
         return $this->s3Client->getObjectUrl($this->attachedFile->s3_object_config['Bucket'], $this->path($styleName), null, ['PathStyle' => true]);
     }
 
+
+    /**
+     * Return the SIGNED url for a file upload.
+     *
+     * @param string $styleName
+     *
+     * @return string
+     */
+
+    public function signedurl($styleName)
+    {
+
+      $cmd = $this->s3Client->getCommand('GetObject', [
+          'Bucket' => $this->attachedFile->s3_object_config['Bucket'],
+          'Key' => $this->path($styleName)
+      ]);
+      $request = $this->s3Client->createPresignedRequest($cmd, '+20 minutes');
+      return  (string) $request->getUri();
+    }
+
     /**
      * Return the key the uploaded file object is stored under within a bucket.
      *

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -46,12 +46,23 @@ class Validator implements ValidatorInterface
             throw new Exceptions\InvalidUrlOptionException('Invalid Path: a bucket is required for s3 storage.', 1);
         }
 
-        if (!$options['s3_client_config']['secret']) {
-            throw new Exceptions\InvalidUrlOptionException('Invalid Path: a secret is required for s3 storage.', 1);
-        }
+	/*
+	*
+	* On an AWS EC2 instance, checks if security credentials are available. If not, requires the variables.
+	* If so, the AWS PHP SDK will use those credentials to handle all of the API calls
+	*
+	*/
+	$file = 'http://169.254.169.254/latest/meta-data/iam/security-credentials/';
+	$file_headers = @get_headers($file);
+	if(!$file_headers || $file_headers[0] == 'HTTP/1.1 404 Not Found') {
 
-        if (!$options['s3_client_config']['key']) {
-            throw new Exceptions\InvalidUrlOptionException('Invalid Path: a key is required for s3 storage.', 1);
-        }
+		if (!$options['s3_client_config']['secret']) {
+        	    throw new Exceptions\InvalidUrlOptionException('Invalid Path: a secret is required for s3 storage.', 1);
+        	    }
+
+	        if (!$options['s3_client_config']['key']) {
+            	throw new Exceptions\InvalidUrlOptionException('Invalid Path: a key is required for s3 storage.', 1);
+        	}
+	}
     }
 }


### PR DESCRIPTION
Hi,

I am not much of a PHP developer but I am certainly an AWS Admin who loves not to have to write keys on the instances. Therefore, I added this condition in the validator so if an IAM profile is available for the instance to use, the PHP SDK can use that and will with no addition configuration needed, and so the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY variables aren't necessary.

If no IAM profile is set / available, like it wouldn't on someone's laptop, they have to set their key and so the validator will take over.

Feel free to change my code, it's not much of a change but a great feature to have.