### PR TITLE
PHP 7.2 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.4",
-        "symfony/http-foundation": "~2.3|~3.0",
+        "symfony/http-foundation": "~2.3|~3.0|~4.0",
         "imagine/imagine": "~0.6.2",
         "doctrine/inflector": "~1"
     },

--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -2,14 +2,14 @@
 
 namespace Codesleeve\Stapler;
 
-use Codesleeve\Stapler\Interfaces\Attachment as AttachmentInterface;
-use Codesleeve\Stapler\Interfaces\Interpolator as InterpolatorInterface;
-use Codesleeve\Stapler\Interfaces\Resizer as ResizerInterface;
-use Codesleeve\Stapler\Interfaces\Storage as StorageInterface;
+use DateTime;
+use JsonSerializable;
 use Codesleeve\Stapler\ORM\StaplerableInterface;
 use Codesleeve\Stapler\Factories\File as FileFactory;
-use JsonSerializable;
-use DateTime;
+use Codesleeve\Stapler\Interfaces\Resizer as ResizerInterface;
+use Codesleeve\Stapler\Interfaces\Storage as StorageInterface;
+use Codesleeve\Stapler\Interfaces\Attachment as AttachmentInterface;
+use Codesleeve\Stapler\Interfaces\Interpolator as InterpolatorInterface;
 
 class Attachment implements AttachmentInterface, JsonSerializable
 {
@@ -386,7 +386,7 @@ class Attachment implements AttachmentInterface, JsonSerializable
      */
     public function getInstanceClass()
     {
-        return get_class($this->instance);
+        return is_null($this->instance) ? null : get_class($this->instance);
     }
 
     /**


### PR DESCRIPTION
> Note: Explicitly passing NULL as the object is no longer allowed as of PHP 7.2.0. The parameter is still optional and calling get_class() without a parameter from inside a class will work, but passing NULL now emits an E_WARNING notice.

http://php.net/manual/en/function.get-class.php