### PR TITLE
hasAttachedFile bugfix for S3 

### DIFF
--- a/src/Factories/Attachment.php
+++ b/src/Factories/Attachment.php
@@ -16,7 +16,7 @@ class Attachment
      *
      * @return \Codesleeve\Stapler\Attachment
      */
-    public static function create($name, array $options)
+    public static function create($name, array $options, $instance = null)
     {
         $options = static::mergeOptions($options);
         Stapler::getValidatorInstance()->validateOptions($options);
@@ -24,6 +24,7 @@ class Attachment
 
         $className = Stapler::getConfigInstance()->get('bindings.attachment');
         $attachment = new $className($config, $interpolator, $resizer);
+        $attachment->setInstance($instance);
 
         $storageDriver = StorageFactory::create($attachment);
         $attachment->setStorageDriver($storageDriver);

--- a/src/ORM/EloquentTrait.php
+++ b/src/ORM/EloquentTrait.php
@@ -32,7 +32,7 @@ trait EloquentTrait
      */
     public function hasAttachedFile($name, array $options = [])
     {
-        $attachment = AttachmentFactory::create($name, $options);
+        $attachment = AttachmentFactory::create($name, $options, $this);
         $attachment->setInstance($this);
         $this->attachedFiles[$name] = $attachment;
     }


### PR DESCRIPTION
So, `hasAttachedFile` seems to have a bug when in use with S3. 

It calls `setInstance` too late because the storage factory for S3 (`Storage::create`) calls `Stapler::getS3ClientInstance`, which needs the `$attachedFile` to have an associated instance. 

This feels hacky, but fixes that problem.